### PR TITLE
bug report & analytics url changed

### DIFF
--- a/appconfig/src/main/kotlin/io/element/android/appconfig/RageshakeConfig.kt
+++ b/appconfig/src/main/kotlin/io/element/android/appconfig/RageshakeConfig.kt
@@ -11,7 +11,7 @@ object RageshakeConfig {
     /**
      * The URL to submit bug reports to.
      */
-    const val BUG_REPORT_URL = "https://riot.im/bugreports/submit"
+    const val BUG_REPORT_URL = "https://rageshake.the-revivalists.org/api/submit"
 
     /**
      * As per https://github.com/matrix-org/rageshake:

--- a/features/onboarding/impl/src/main/res/values/localazy.xml
+++ b/features/onboarding/impl/src/main/res/values/localazy.xml
@@ -3,7 +3,7 @@
   <string name="screen_onboarding_sign_in_manually">"Sign in manually"</string>
   <string name="screen_onboarding_sign_in_with_qr_code">"Sign in with QR code"</string>
   <string name="screen_onboarding_sign_up">"Create account"</string>
-  <string name="screen_onboarding_welcome_message">"Welcome to the fastest %1$s ever. Supercharged for speed and simplicity."</string>
-  <string name="screen_onboarding_welcome_subtitle">"Welcome to %1$s. Supercharged, for speed and simplicity."</string>
-  <string name="screen_onboarding_welcome_title">"Be in your element"</string>
+  <string name="screen_onboarding_welcome_message">"Welcome to our new app. Supercharged for speed and simplicity."</string>
+  <string name="screen_onboarding_welcome_subtitle">"Welcome to our new app. Supercharged for speed and simplicity."</string>
+  <string name="screen_onboarding_welcome_title">"The Revivalists"</string>
 </resources>

--- a/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryConfig.kt
+++ b/services/analyticsproviders/sentry/src/main/kotlin/io/element/android/services/analyticsproviders/sentry/SentryConfig.kt
@@ -9,7 +9,7 @@ package io.element.android.services.analyticsproviders.sentry
 
 object SentryConfig {
     const val NAME = "Sentry"
-    const val DNS = "https://32f7ff6a6e724f90838b7654042b2e81@sentry.tools.element.io/59"
+    const val DNS = "https://61bb06f3ba116a7205d604976b97a3b6@o4508071889076224.ingest.de.sentry.io/4508071897530448"
     const val ENV_DEBUG = "DEBUG"
     const val ENV_RELEASE = "RELEASE"
 }


### PR DESCRIPTION
1. bug reporting url is now pointing to our instance of rageshake .i.e. the server tool to report element x bugs
2. analytics url has also been changed so that we can get data of how the app interface is being used by users
3. Title, subtitle changed on on-boarding screen.