### PR TITLE
disable e2e in DMs

### DIFF
--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
@@ -171,10 +171,8 @@ class ConfigureRoomPresenter @Inject constructor(
             } else {
                 CreateRoomParameters(
                     name = config.roomName,
-                    topic = config.topic,
-                    // Because we skip device verification. It shows a warning in private room in all msgs that msg has been sent from an unverified device. 
-                    // Hence disabling encryption in private rooms too.                     
-                    isEncrypted = false, 
+                    topic = config.topic,                                   
+                    isEncrypted = config.roomVisibility is RoomVisibilityState.Private,
                     isDirect = false,
                     visibility = RoomVisibility.Private,
                     preset = RoomPreset.PRIVATE_CHAT,

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
@@ -172,7 +172,9 @@ class ConfigureRoomPresenter @Inject constructor(
                 CreateRoomParameters(
                     name = config.roomName,
                     topic = config.topic,
-                    isEncrypted = config.roomVisibility is RoomVisibilityState.Private,
+                    // Because we skip device verification. It shows a warning in private room in all msgs that msg has been sent from an unverified device. 
+                    // Hence disabling encryption in private rooms too.                     
+                    isEncrypted = false, 
                     isDirect = false,
                     visibility = RoomVisibility.Private,
                     preset = RoomPreset.PRIVATE_CHAT,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -343,7 +343,7 @@ class RustMatrixClient(
     override suspend fun createDM(userId: UserId): Result<RoomId> {
         val createRoomParams = CreateRoomParameters(
             name = null,
-            isEncrypted = true,
+            isEncrypted = false,
             isDirect = true,
             visibility = RoomVisibility.Private,
             preset = RoomPreset.TRUSTED_PRIVATE_CHAT,


### PR DESCRIPTION
Because we skip device verification. It shows a warning in private room in all msgs that msg has been sent from an unverified device. 
It shows a little warning sign on every message which is annoying.
we only need to disable e2e by default for DMs. if needed we should have the capability to create e2e private rooms. 