### PR TITLE
disable location sharing and enable room directory

### DIFF
--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -24,7 +24,7 @@ enum class FeatureFlags(
     LocationSharing(
         key = "feature.locationsharing",
         title = "Allow user to share location",
-        defaultValue = { true },
+        defaultValue = { false },
         isFinished = true,
     ),
     Polls(
@@ -79,7 +79,7 @@ enum class FeatureFlags(
         key = "feature.roomdirectorysearch",
         title = "Room directory search",
         description = "Allow user to search for public rooms in their homeserver",
-        defaultValue = { false },
+        defaultValue = { true },
         isFinished = false,
     ),
     ShowBlockedUsersDetails(


### PR DESCRIPTION
- [x] no need to give members a feature to share location with each other.
- [x] enabled room directory. public rooms are enabled and are searchable now.